### PR TITLE
Update docker-compose to use mariadb:10 image directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # MYSQL_USER - database user
     # MYSQL_PASSWORD - database user password
     db:
-        image: silintl/mariadb:latest
+        image: mariadb:10
         volumes_from:
             - data
         ports:


### PR DESCRIPTION
## Changes

* Use mariadb:10 image instead of the SIL image in `docker-compose.yml`.